### PR TITLE
Fix chromium-browser Exec line so it passes the URL when you use xdg-open URL

### DIFF
--- a/usr/share/budgie-desktop/chromium-browser.desktop
+++ b/usr/share/budgie-desktop/chromium-browser.desktop
@@ -167,7 +167,7 @@ Comment[vi]=Truy cập Internet
 Comment[zh_CN]=访问互联网
 Comment[zh_HK]=連線到網際網路
 Comment[zh_TW]=連線到網際網路
-Exec=chromium-browser --password-store=basic ubuntubudgie.org
+Exec=chromium-browser --password-store=basic %U
 Terminal=false
 X-MultipleArgs=false
 Type=Application


### PR DESCRIPTION
I recently switched from Ubuntu to Ubuntu Budgie, and noticed that whenever I would click a link (in Terminix, Slack, etc.) to open it in my browser, it would instead go to https://ubuntubudgie.org/.

Found https://askubuntu.com/questions/540939/xdg-open-only-opens-a-new-tab-in-a-new-chromium-window-despite-passing-it-a-url and confirmed that changing the `Exec` line in /usr/share/applications/chromium-browser.desktop to include `%U` does indeed resolve the issue for me. 

I imagine ubuntubudgie.org was hard-coded in the command line in order to make it open to that page by default ... which indeed it was doing, but also had the side effect of not letting you open specific web pages with `xdg-open`/clicking links in apps. Perhaps that goal could accomplish in a different way such as setting  https://ubuntubudgie.org/ as the default home page in the chromium config file?