### PR TITLE
Edited showtime overrides to match the latest version.

### DIFF
--- a/debian/budgie-desktop-environment.gsettings-override
+++ b/debian/budgie-desktop-environment.gsettings-override
@@ -21,8 +21,8 @@ hide-mode='window-dodge'
 zoom-enabled=true
 
 [org.ubuntubudgie.plugins.budgie-showtime]
-timefont='Sawasdee'
-datefont='Sawasdee'
+timefont='Sawasdee 91'
+datefont='Sawasdee 35'
 xposition=2
 leftalign=false
 linespacing=-20


### PR DESCRIPTION
Font field now includes font size. Separate font size field was removed, but wasn't set in overrides I noticed. 