### PR TITLE
Trying to remove the totem.thumbnailer

### DIFF
--- a/debian/budgie-desktop-environment.install
+++ b/debian/budgie-desktop-environment.install
@@ -15,6 +15,5 @@ xfce4-terminal/* /etc/xdg/xdg-budgie-desktop/xfce4/terminal
 panel_override/* /usr/share/budgie-desktop/
 schemas/25_budgie-desktop-environment.gschema.override /usr/share/glib-2.0/schemas
 showdesktop /usr/share/budgie-desktop/
-thumbnail_override/* /usr/share/budgie-desktop/
 codename-wallpapers/ubuntu-budgie-codename-wallpapers.xml /usr/share/gnome-background-properties
 codename-wallpapers/budgie-codename.png /usr/share/backgrounds/budgie/

--- a/debian/budgie-desktop-environment.postinst
+++ b/debian/budgie-desktop-environment.postinst
@@ -1,5 +1,4 @@
 #!/bin/bash
-# add totemthumbnailer config if it doesn't already exist
 # This script can be called in the following ways:
 #
 # After the package was installed:
@@ -83,15 +82,6 @@ function template_cleanup () {
 
 case "$1" in
     configure)
-
-    # we want to be absolutely sure that before we copy ubuntu budgie's
-    # version of totem.thumbnailer that the user hasn't already got this
-    # file installed via totem.
-    # N.B. we are safe here to-do this because if totem is subsequently installed
-    # totem will safely overwrite our file without error
-    if [ ! -e /usr/share/thumbnailers/totem.thumbnailer ]; then
-        cp /usr/share/budgie-desktop/totem.thumbnailer /usr/share/thumbnailers/
-    fi
 
     plank_cleanup
     template_cleanup

--- a/debian/budgie-desktop-environment.postrm
+++ b/debian/budgie-desktop-environment.postrm
@@ -1,5 +1,4 @@
 #! /bin/sh
-# remove totem thumbnailer config if we added it
 # This script can be called in the following ways:
 #
 # see: dh_installdeb(1)
@@ -24,16 +23,6 @@ applications/nemo.desktop
 
 case "$1" in
        purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-
-        # postinst would have installed our version of totem.thumbnailer
-        # now that we are removing this package, lets double check that it is
-        # indeed our file that is installed - it could have been installed via
-        # totem and in this case we should just leave well alone.
-        if [ -e /usr/share/thumbnailers/totem.thumbnailer ]; then
-            if grep -q "ffmpegthumbnailer" /usr/share/thumbnailers/totem.thumbnailer; then
-                rm -f /usr/share/thumbnailers/totem.thumbnailer
-            fi
-        fi
 
         ;;
 

--- a/debian/control
+++ b/debian/control
@@ -59,7 +59,6 @@ Description: Desktop environment customisation for Ubuntu Budgie
  Installs:
    Ubuntu Budgie panel configuration
    gsettings overrides
-   totem thumbnailer config using ffmpegthumbnailer
    Tilix integration
    ubuntu and budgie-desktop gsettings overrides
    applies the default icon-theme for GTK+ applications

--- a/thumbnail_override/totem.thumbnailer
+++ b/thumbnail_override/totem.thumbnailer
@@ -1,4 +1,0 @@
-[Thumbnailer Entry]
-TryExec=ffmpegthumbnailer
-Exec=ffmpegthumbnailer -s %s -i %i -o %o -c png -t 10
-MimeType=audio/x-pn-realaudio;audio/3gpp;audio/3gpp2;audio/aac;audio/ac3;audio/AMR;audio/AMR-WB;audio/basic;audio/dv;audio/eac3;audio/flac;audio/m4a;audio/midi;audio/mp1;audio/mp2;audio/mp3;audio/mp4;audio/mpeg;audio/mpg;audio/ogg;audio/opus;audio/prs.sid;audio/scpls;audio/vnd.rn-realaudio;audio/wav;audio/webm;audio/x-aac;audio/x-aiff;audio/x-ape;audio/x-flac;audio/x-gsm;audio/x-it;audio/x-m4a;audio/x-matroska;audio/x-mod;audio/x-mp1;audio/x-mp2;audio/x-mp3;audio/x-mpg;audio/x-mpeg;audio/x-ms-asf;audio/x-ms-asx;audio/x-ms-wax;audio/x-ms-wma;audio/x-musepack;audio/x-pn-aiff;audio/x-pn-au;audio/x-pn-wav;audio/x-pn-windows-acm;audio/x-realaudio;audio/x-real-audio;audio/x-s3m;audio/x-sbc;audio/x-shorten;audio/x-speex;audio/x-stm;audio/x-tta;audio/x-wav;audio/x-wavpack;audio/x-vorbis;audio/x-vorbis+ogg;audio/x-xm;application/x-flac;


### PR DESCRIPTION
I made some changes to remove totem.thumbnailer from the budgie-desktop-environment, since ffmpegthumbnailer 2.3.0, available in Ubuntu 26.04, already comes with a file that does the same thing as totem.thumbnailer.